### PR TITLE
Marshmellow Dependency Change to fix 'strict' error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'boto3',
         'cryptography',
         'ipaddress',
-        'marshmallow',
+        'marshmallow<3',
         'kmsauth'
     ],
     extras_require={


### PR DESCRIPTION
## Description
The "strict" keyword argument was removed in a newer version of one of the Marshmallow dependency, and one of the files in Bless uses this and errors out. This pins the version of Marshmallow > 3.0. 

## JIRA ticket number
https://zendesk.atlassian.net/browse/SECURE-336